### PR TITLE
minimalistic-assert instead node assert

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+
+npm-debug.log

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var assert = require('assert')
+var assert = require('minimalistic-assert')
 
 var int53 = {}
 

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "0.2.3",
   "description": "silly 53bit integer buffer serialization",
   "main": "index.js",
+  "files": [
+    "index.js"
+  ],
   "scripts": {
     "test": "node test.js"
   },
@@ -17,5 +20,8 @@
     "number"
   ],
   "author": "Danny Coates <dannycoates@gmail.com>",
-  "license": "BSD"
+  "license": "BSD",
+  "dependencies": {
+    "minimalistic-assert": "^1.0.0"
+  }
 }


### PR DESCRIPTION
This makes browser bundle (via browserify) less in 9x.

``` shell
$ ./node_modules/.bin/browserify index.js |wc -c
```

master -- 33988, with PR -- 3649
