### PR TITLE
use throw instead of console.assert to preserve compatibilty with node@8

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,10 @@ var int53 = {}
 var MAX_UINT32 = 0x00000000FFFFFFFF
 var MAX_INT53 =  0x001FFFFFFFFFFFFF
 
+function assert (test, message) {
+	if(!test) throw new Error(message)
+}
+
 function onesComplement(number) {
 	number = ~number
 	if (number < 0) {
@@ -12,8 +16,8 @@ function onesComplement(number) {
 }
 
 function uintHighLow(number) {
-	console.assert(number > -1 && number <= MAX_INT53, "number out of range")
-	console.assert(Math.floor(number) === number, "number must be an integer")
+	assert(number > -1 && number <= MAX_INT53, "number out of range")
+	assert(Math.floor(number) === number, "number must be an integer")
 	var high = 0
 	var signbit = number & 0xFFFFFFFF
 	var low = signbit < 0 ? (number & 0x7FFFFFFF) + 0x80000000 : signbit
@@ -44,11 +48,11 @@ function toDouble(high, low, signed) {
 	if (signed && (high & 0x80000000) !== 0) {
 		high = onesComplement(high)
 		low = onesComplement(low)
-		console.assert(high < 0x00200000, "number too small")
+		assert(high < 0x00200000, "number too small")
 		return -((high * (MAX_UINT32 + 1)) + low + 1)
 	}
 	else { //positive
-		console.assert(high < 0x00200000, "number too large")
+		assert(high < 0x00200000, "number too large")
 		return (high * (MAX_UINT32 + 1)) + low
 	}
 }

--- a/test.js
+++ b/test.js
@@ -1,30 +1,34 @@
 var int53 = require('./index')
 
+function assert (test) {
+	if(!test) throw new Error('assert failed')
+}
+
 function testUInt64(x) {
 	var b = new Buffer(8)
 	int53.writeUInt64BE(x, b)
-	console.assert(x === int53.readUInt64BE(b))
+	assert(x === int53.readUInt64BE(b))
 
 	int53.writeUInt64LE(x, b)
-	console.assert(x === int53.readUInt64LE(b))
+	assert(x === int53.readUInt64LE(b))
 }
 
 function testInt64(x) {
 	var b = new Buffer(8)
 	int53.writeInt64BE(x, b)
-	console.assert(x === int53.readInt64BE(b))
+	assert(x === int53.readInt64BE(b))
 
 	int53.writeInt64LE(x, b)
-	console.assert(x === int53.readInt64LE(b))
+	assert(x === int53.readInt64LE(b))
 }
 
 function error(func, number, message) {
 	try {
 		func(number)
-		console.assert(false)
+		assert(false)
 	}
 	catch (e) {
-		console.assert(e.message === message, e.message)
+		assert(e.message === message, e.message)
 	}
 }
 
@@ -64,10 +68,10 @@ error(testInt64, -1.1, 'number must be an integer')
 try {
 	var b = new Buffer('FFDFFFFFFFFFFFFF', 'hex')
 	var x = int53.readInt64BE(b)
-	console.assert(false)
+	assert(false)
 }
 catch (e) {
-	console.assert(e.message === 'number too small', e.message)
+	assert(e.message === 'number too small', e.message)
 }
 
 console.log("SUCCESS!")


### PR DESCRIPTION
in node.js `console.assert` would throw an error, as one might expect with a name like "assert"
however, it seems in the browser, `console.assert` did not throw, and eventually node changed to be the same as in browsers.

I gather that you expected it to throw, as you also used it in the tests, and in node@11 it gives a false positive:

```
$ npm test

> int53@0.2.3 test /home/dominic/c/int53
> node test.js

Assertion failed: number out of range
Assertion failed: number too large
Assertion failed: number out of range
Assertion failed: number too large
Assertion failed
Assertion failed: number out of range
Assertion failed
Assertion failed: number out of range
Assertion failed
Assertion failed
Assertion failed: number must be an integer
Assertion failed
Assertion failed: number must be an integer
Assertion failed
Assertion failed
Assertion failed: number too large
Assertion failed
Assertion failed: number out of range
Assertion failed: number out of range
Assertion failed
Assertion failed: number must be an integer
Assertion failed
Assertion failed: number must be an integer
Assertion failed
Assertion failed
Assertion failed: number too small
Assertion failed
SUCCESS!
(node:20191) [DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.
```